### PR TITLE
Removed FormFactory from global scope declaration

### DIFF
--- a/public/tutorials/introduction/t-checkout-and-step-engine-spryker-commerce-os.htm
+++ b/public/tutorials/introduction/t-checkout-and-step-engine-spryker-commerce-os.htm
@@ -451,7 +451,6 @@ class StepFactory extends SprykerShopStepFactory
 					<p><pre><code class="language-PHP line-numbers">
 namespace Pyz\Yves\CheckoutPage;
  
-use Pyz\Yves\CheckoutPage\Form\FormFactory;
 use Pyz\Yves\CheckoutPage\Process\StepFactory;
 use SprykerShop\Yves\CheckoutPage\CheckoutPageFactory as SprykerShopCheckoutPageFactory;
  


### PR DESCRIPTION
At this point in the tutorial, Pyz\Yves\CheckoutPage\Form\FormFactory; is not needed and it was not used.  In order not to confuse newbies using your documentation, I suggest removing it. It was used/Included multiple steps down the tutorial, but not at this point.