### PR TITLE
fixed code highlighting bug and added missing console command for cre…

### DIFF
--- a/public/tutorials/introduction/t-different-stores-different-logic-landing-pages.htm
+++ b/public/tutorials/introduction/t-different-stores-different-logic-landing-pages.htm
@@ -251,7 +251,7 @@
                                                     <ol>
                                                         <li value="1">Add a <i>Controller</i> directory in the <b>Communication</b> layer of the Application module in Zed in <code>src/Pyz/Zed</code>.</li>
                                                         <li value="2">Inside the added <i>Controller</i> directory, extend the <code>IndexController</code> to return just a string when calling the <code>indexAction()</code>.
-					<p><pre><code class="language=PHP line-numbers">
+					<p><pre><code class="language-PHP line-numbers">
 namespace Pyz\Zed\Application\Communication\Controller;
  
 use Spryker\Zed\Application\Communication\Controller\IndexController as SprykerIndexController;
@@ -299,7 +299,8 @@ class IndexController extends AbstractController
 			</code></pre></p></li>
                                                         <li value="6">The shop is ready to support both landing pages for both stores. What is left now is modifying the virtual machine to redirect you to the right store. Change the store in <i>Nginx</i> config for zed:
 <ol><li value="1">Open the config file <code>sudo vim /etc/nginx/sites-available/DE_development_zed</code>.</li><li value="2">Change the <var>$application_store</var> to <b>DEMO</b>.</li><li value="3">Save the changes.</li></ol></li>
-                                                        <li value="7">Finally, restart <i>Nginx</i> ny running <code>sudo /etc/init.d/nginx restart</code></li>
+                                                        <li value="7">Restart <i>Nginx</i> ny running <code>sudo /etc/init.d/nginx restart</code></li>
+					    		<li value="8">Finally, run  <code> console data:import:store</code>. This command will create a store record in our spy_store database table. </li>
                                                     </ol>
                                                     <p>Check the <a href="http://zed.de.suite.local/">Backend Office</a> again to see the new message for the <b>DEMO</b> store.</p>
                                                     <p>&#160;</p>


### PR DESCRIPTION
…ating a new store

The command "console data:import:store" was missing from this tutorial, I added it as point 8. Readers will encounter "a missing store" error if a newly added store is not added to the spy_store table.